### PR TITLE
Graphql refinement

### DIFF
--- a/app/graphql/mutations/delete_farmer.rb
+++ b/app/graphql/mutations/delete_farmer.rb
@@ -1,12 +1,12 @@
 module Mutations
   class DeleteFarmer < BaseMutation
-    field :id, ID, null: true
+    field :response, ID, null: true
     argument :id, ID, required: false
 
     def resolve(id:)
       farmer = Farmer.find(id)
       farmer.destroy
-      { id: id }
-    end
+      { response: "You've successfully destroyed this farmer and their grains." }
+     end
   end
 end

--- a/app/graphql/mutations/delete_farmer.rb
+++ b/app/graphql/mutations/delete_farmer.rb
@@ -1,7 +1,6 @@
 module Mutations
   class DeleteFarmer < BaseMutation
     field :id, ID, null: true
-
     argument :id, ID, required: false
 
     def resolve(id:)

--- a/app/graphql/mutations/delete_grain.rb
+++ b/app/graphql/mutations/delete_grain.rb
@@ -1,0 +1,12 @@
+module Mutations
+  class DeleteGrain < BaseMutation
+    field :response, ID, null: true
+    argument :id, ID, required: false
+
+    def resolve(id:)
+      grain = Grain.find(id)
+      grain.destroy
+      { response: "You've successfully destroyed this grain." }
+    end
+  end
+end

--- a/app/graphql/mutations/update_farmer.rb
+++ b/app/graphql/mutations/update_farmer.rb
@@ -1,6 +1,6 @@
 module Mutations
   class UpdateFarmer < BaseMutation
-    field :post, Types::FarmerType, null: false
+    field :farmer, Types::FarmerType, null: false
 
     argument :id, ID, required: true
     argument :attributes, Types::FarmerAttributes, required: true
@@ -8,7 +8,7 @@ module Mutations
     def resolve(id: nil, attributes: nil)
       farmer = Farmer.find(id)
       if farmer.update(attributes.to_h)
-        {post: farmer}
+        {farmer: farmer}
       else
         raise GraphQL::ExecutionError, post.errors.full_messages.join(", ")
       end

--- a/app/graphql/mutations/update_grain.rb
+++ b/app/graphql/mutations/update_grain.rb
@@ -1,6 +1,6 @@
 module Mutations
   class UpdateGrain < BaseMutation
-    field :post, Types::GrainType, null: false
+    field :grain, Types::GrainType, null: false
 
     argument :id, ID, required: true
     argument :attributes, Types::GrainAttributes, required: true
@@ -8,7 +8,7 @@ module Mutations
     def resolve(id: nil, attributes: nil)
       grain = Grain.find(id)
       if grain.update(attributes.to_h)
-        {post: grain}
+        {grain: grain}
       else
         raise GraphQL::ExecutionError, post.errors.full_messages.join(", ")
       end

--- a/app/graphql/types/grain_attributes.rb
+++ b/app/graphql/types/grain_attributes.rb
@@ -8,7 +8,6 @@ module Types
     argument :test_weight, Float
     argument :farmers_notes, String
     argument :farmer_id, Integer
-    # argument :farmer, [Types::FarmerType], required: false
     argument :created_at, GraphQL::Types::ISO8601DateTime, required: false
     argument :updated_at, GraphQL::Types::ISO8601DateTime, required: false
   end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -6,8 +6,10 @@ module Types
 
     field :delete_farmer, mutation: Mutations::DeleteFarmer
 
-    field :create_grain, mutation: Mutations::CreateGrain
+    field :create_grain,  mutation: Mutations::CreateGrain
 
-    field :update_grain, mutation: Mutations::UpdateGrain
+    field :update_grain,  mutation: Mutations::UpdateGrain
+
+    field :delete_grain,  mutation: Mutations::DeleteGrain
   end
 end

--- a/app/models/farmer.rb
+++ b/app/models/farmer.rb
@@ -1,5 +1,5 @@
 class Farmer < ApplicationRecord
-  has_many :grains
+  has_many :grains, dependent: :destroy
 
   validates :email, presence: true, uniqueness: true
 end

--- a/json_contract.md
+++ b/json_contract.md
@@ -441,9 +441,8 @@ Response:
 ```
 **Create a Farmer**
 ```
-mutation createFarmer {
-    createFarmer(input:
-            "CreateFarmerInput!"
+mutation {
+    createFarmer (input: {
             name: "Marco",
             email: "marco@gmail.com",
             phone: "303-555-1750",
@@ -451,8 +450,7 @@ mutation createFarmer {
             region: "West",
             bio: "I was born in Venice",
             photoUrl: "photo_path.jpg"  
-          ) {
-
+          }) {
             name
             bio
             }
@@ -491,8 +489,10 @@ mutation {
 ```
 **Delete a Grain**
 ```
-{
-    grainEdit
-
-}
+mutation {
+   deleteGrain( input:{ id: "16" })
+   {
+       response   
+           }
+       }
 ```

--- a/spec/graphql/mutations/grains/delete_grain_spec.rb
+++ b/spec/graphql/mutations/grains/delete_grain_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+module Mutations
+  RSpec.describe DeleteGrain, type: :request do
+    describe 'resolver' do
+      it 'deletes a grain' do
+        farmermutation = CreateFarmer.new(field: nil, object: nil, context: {})
+
+        farmer2 = farmermutation.resolve(name: 'Cool Name', email: 'email@email.com', phone: '444-444-4444', address: '5678 Dusty Rd, Tatooine, OK', region: 'East', bio: 'Cool bio.', photo_url: 'picture_link_here.jpeg')
+
+        mutation = CreateGrain.new(field: nil, object: nil, context: {})
+
+        grain = mutation.resolve(name: "Red Turkey Wheat",
+            moisture: 12.5,
+            test_weight: 42.0,
+            falling_number: 175.3,
+            protein: 8.3,
+            farmers_notes: "Gobble Gobble!",
+            farmer_id: farmer2)
+
+        expect(Grain.last.name).to eq("Red Turkey Wheat")
+        expect(Grain.count).to eq(9)
+
+        deleted = DeleteGrain.new(field: nil, object: nil, context: {})
+        deleted.resolve(id: grain.id)
+
+        expect(Grain.count).to eq(8)
+        expect(Grain.last.name).to_not eq("Red Turkey Wheat")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Project Management
Issue name: Grain endpoints(mutations/queries)

Closes #6  

------------------------------------------------------------------------------
### Feature Status
* [x] Completed


------------------------------------------------------------------------------
### Test coverage

If below 100%, what still needs testing:
- sad path/edge case testing

------------------------------------------------------------------------------
### Change Log

What I did:
- add delete grain method. Also added dependent destroy on farmer model. tested locally to make sure it removes grains when deleting a farmer.
- Updated field and return value for delete mutations. Now returns a string confirming they've successfully deleted a grain/farmer
- updated fields on Update mutations for farmer and grains to be more intuitive.

Things to consider:
- Graphql has some pretty extensive error handling, but we might want to write our own messages or simplify the response for front end

What needs to be refactored:
- Nothing at the moment

What still needs help:
- I don't think there's any CRUD functionality left, but I could be missing something.
